### PR TITLE
Added support for introductions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ runs out.
 A queue of inbound attachments that are pending download. If downloading fails, downloads will be
 re-queued here for a limited period of time until they either send successfully or time runs out.
 
+### /intro/from/fromIdentityKey/toIdentityKey
+An index of Introduction messages keyed to the contact who introduced us and then the contact to
+whom we're being introduced.
+
+### /intro/to/toIdentityKey/fromIdentityKey
+An index of Introduction messages keyed to the contact to whom we're being introduced and then the
+contact who introduced us.
+
 ## Included Signal Code
 The included Signal code (like AttachmentCipherInputStream) comes from https://github.com/signalapp/Signal-Android, not from https://github.com/signalapp/libsignal-service-java
 
@@ -76,3 +84,11 @@ This auto-formats all Kotlin files in the project.
 ./gradlew ktlintCheck
 
 This manually runs the linter against all Kotlin files in the project.
+
+## Entropy Issues Testing on Emulators
+This library uses a lot of cryptography routines, which uses up available entropy on systems.
+If you're frequently running the tests on emulators or devices which you don't actually use, the
+system may run out of entropy and the tests will slow down and eventually even stop working.
+
+The solution is to run the tests on a device or emulator on which you also use the UI, which helps
+regenerate entropy.

--- a/messaging/src/androidTest/java/io/lantern/messaging/MessagingTest.kt
+++ b/messaging/src/androidTest/java/io/lantern/messaging/MessagingTest.kt
@@ -985,6 +985,158 @@ class MessagingTest : BaseMessagingTest() {
         }
     }
 
+    @Test
+    fun testIntroductions() {
+        testInCoroutine {
+            newDB.use { dogDB ->
+                newDB.use { catDB ->
+                    newDB.use { fishDB ->
+                        newDB.use { ownerDB ->
+                            newMessaging(dogDB, "dog").with { dog ->
+                                newMessaging(catDB, "cat").with { cat ->
+                                    newMessaging(fishDB, "fish").with { fish ->
+                                        newMessaging(ownerDB, "owner").with { owner ->
+                                            doTestIntroductions(dog, cat, fish, owner)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun doTestIntroductions(
+        dog: Messaging,
+        cat: Messaging,
+        fish: Messaging,
+        owner: Messaging
+    ) {
+        val dogId = dog.myId.id
+        val catId = cat.myId.id
+        val fishId = fish.myId.id
+        val ownerId = owner.myId.id
+
+        // first connect owner with all the pets
+        owner.addOrUpdateDirectContact(dogId, "Dog")
+        dog.addOrUpdateDirectContact(ownerId, "Owner")
+        owner.addOrUpdateDirectContact(catId, "Cat")
+        cat.addOrUpdateDirectContact(ownerId, "Owner")
+        owner.addOrUpdateDirectContact(fishId, "Fish")
+        fish.addOrUpdateDirectContact(ownerId, "Owner")
+
+        // call introduce with too few arguments
+        try {
+            owner.introduce(listOf(dogId))
+            fail("Introducing only one contact should not work")
+        } catch (e: java.lang.IllegalArgumentException) {
+            // okay
+        }
+
+        // introduce all the pets to each other
+        owner.introduce(listOf(dogId, catId, fishId))
+
+        // introduce them again to make sure we can handle duplicate introductions
+        owner.introduce(listOf(dogId, catId, fishId))
+
+        // make sure everyone received an introduction to everyone
+        val introducedParties = listOf(dog, cat, fish)
+        introducedParties.forEach { me ->
+            introducedParties.forEach { them ->
+                if (me != them) {
+                    val msgPath = me.waitFor<String>(
+                        ownerId.introductionIndexPathByFrom(them.myId.id),
+                        "${me.myId.id} should have gotten an introduction to ${them.myId.id}",
+                        duration = 60.seconds,
+                    )
+                    val msg = me.db.get<Model.StoredMessage>(msgPath)
+                    assertNotNull(msg)
+                    assertTrue(msg.hasIntroduction())
+                    assertEquals(
+                        owner.introductionsDisappearAfterSeconds,
+                        msg.disappearAfterSeconds
+                    )
+                }
+            }
+        }
+
+        // test accepting introductions
+        dog.acceptIntroduction(ownerId, catId)
+        val catContact = dog.db.get<Model.Contact>(catId.directContactPath)
+        assertNotNull(catContact, "dog should have a cat contact now")
+        assertEquals(catId, catContact.contactId.id)
+        assertEquals("Cat", catContact.displayName)
+        assertEquals(
+            Model.IntroductionDetails.IntroductionStatus.ACCEPTED,
+            dog.db.introductionMessage(ownerId, catId)?.value?.introduction?.status
+        )
+
+        dog.acceptIntroduction(ownerId, fishId)
+        cat.acceptIntroduction(ownerId, dogId)
+
+        // send a duplicate introduction for fish from dog to cat (but with a different displayName)
+        dog.addOrUpdateDirectContact(fishId, "Dogfish")
+        dog.introduce(listOf(catId, fishId))
+        cat.waitFor<String>(
+            dogId.introductionIndexPathByFrom(fishId),
+            "cat should have gotten an introduction to fish from dog"
+        )
+        cat.waitFor<String>(
+            ownerId.introductionIndexPathByFrom(fishId),
+            "cat should have gotten an introduction to fish from owner"
+        )
+
+        // accept the introduction and make sure status on both introduction messages is updated
+        cat.acceptIntroduction(dogId, fishId)
+        assertEquals(
+            Model.IntroductionDetails.IntroductionStatus.ACCEPTED,
+            cat.db.introductionMessage(dogId, fishId)?.value?.introduction?.status
+        )
+        var catToFishFromDog =
+            cat.db.introductionMessage(ownerId, fishId)?.value
+        assertEquals(
+            Model.IntroductionDetails.IntroductionStatus.ACCEPTED,
+            catToFishFromDog?.introduction?.status
+        )
+        assertEquals(
+            "Fish",
+            catToFishFromDog?.introduction?.originalDisplayName,
+            "originalDisplayName on introduction should be retained"
+        )
+        assertEquals(
+            "Dogfish",
+            catToFishFromDog?.introduction?.displayName,
+            "introduction should have updated to reflect accepted displayName"
+        )
+        val fishContact = cat.db.get<Model.Contact>(fishId.directContactPath)
+        assertEquals(
+            "Dogfish",
+            fishContact?.displayName,
+            "displayName on Contact should match version from accepted introduction"
+        )
+
+        // test deleting introduction messages
+        fish.rejectIntroduction(ownerId, dogId)
+        fish.rejectIntroduction(ownerId, catId)
+        assertNull(
+            fish.db.findOne(Schema.PATH_INTRODUCTIONS_BY_TO.path("%")),
+            "all introductions by to index entries should be deleted"
+        )
+        assertNull(
+            fish.db.findOne(Schema.PATH_INTRODUCTIONS_BY_FROM.path("%")),
+            "all introductions by from index entries should be deleted"
+        )
+
+        try {
+            fish.acceptIntroduction(ownerId, dogId)
+            fail("accepting deleted introduction should not work")
+        } catch (e: java.lang.IllegalArgumentException) {
+            // okay
+        }
+    }
+
     private fun testInCoroutine(fn: suspend () -> Unit) {
         var thrown: Throwable? = null
         runBlocking {

--- a/messaging/src/main/protos/Model.proto
+++ b/messaging/src/main/protos/Model.proto
@@ -67,6 +67,27 @@ message AttachmentWithThumbnail {
   Attachment thumbnail = 2;
 }
 
+// Introduction is an introduction to a potential direct Contact
+message Introduction {
+  bytes id = 1; // the id of the person to whom you're being introduced
+  string displayName = 2; // the display name of person to whom you're being introduced
+}
+
+// Details of an Introduction (attached to both a StoredMessage as well as a StoredIntroduction
+message IntroductionDetails {
+  enum IntroductionStatus {
+    PENDING = 0; // introduction has been made but has not yet been accepted/rejected
+    ACCEPTED = 1; // introduction has been accepted
+  }
+
+  ContactId to = 1; // the id of the contact to which we're being introduced
+  string displayName = 2; // the display name of the contact to whom we're being introduced. This
+                          // may change when accepting an Introduction to the same contact made by
+                          // someone else.
+  string originalDisplayName = 3; // the original display name of the introduction, this will never change
+  IntroductionStatus status = 4; // the status of the introduction
+}
+
 // A text message with attachments, the primary type of message exchanged by users.
 message Message {
   bytes id = 1; // the id of the message, unique under the given sender
@@ -75,6 +96,7 @@ message Message {
   string text = 4;
   map<int32, AttachmentWithThumbnail> attachments = 5; // attachments keyed to unique IDs for each attachment within this message
   int32 disappearAfterSeconds = 6; // if > 0, message should disappear within this many seconds of first being viewed
+  Introduction introduction = 7; // an introduction to another Contact
 }
 
 // A locally stored Message
@@ -104,6 +126,7 @@ message StoredMessage {
   int64 disappearAt = 14; // the unix timestamp in milliseconds of when this message will automatically disappear
   int64 remotelyDeletedAt = 16; // the unix timestamp in milliseconds of when an authorized party remotely deleted this message (will be 0 if the message hasn't been remotely deleted)
   ContactId remotelyDeletedBy = 17; // the id of the contact who remotely deleted this message
+  IntroductionDetails introduction = 18; // if this message was an introduction, this stores details of that introduction
 }
 
 // A reaction to a message


### PR DESCRIPTION
Adds backend support for introductions.

The main data model changes are:

1. StoredMessages which are introductions contain a new `IntroductionDetails` data structure

2. There are two new indexes, `/intro/from` and `/intro/to` that point at introduction StoredMessages based on whom the introduction is from and to whom we're being introduced

- [x] Do the tests pass? Consistently?
- [x] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [x] Can it be QA’d in staging or something like staging?
- [x] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [x] Do we know how we’re going to deploy this?
- [x] Are we clear on what the support and maintenance impact is?
- [x] Did you create new documentation? Is it accessible and in the right place?
- [x] Has existing documentation been updated?