### PR TITLE
Don't process hellos from unknown provisional senders

### DIFF
--- a/messaging/src/androidTest/java/io/lantern/messaging/MessagingTest.kt
+++ b/messaging/src/androidTest/java/io/lantern/messaging/MessagingTest.kt
@@ -234,6 +234,9 @@ class MessagingTest : BaseMessagingTest() {
                             val dogId = dog.myId.id
                             val catId = cat.myId.id
 
+                            logger.debug("Cat is $catId")
+                            logger.debug("Dog is $dogId")
+
                             // We use unsafeSetMyDisplayName to keep the name from being sanitized
                             // here, which allows us to test that it gets sanitized when the
                             // provisional contact turns into a real contact.
@@ -309,7 +312,9 @@ class MessagingTest : BaseMessagingTest() {
                                 "no provisional contact should be stored for an existing contact"
                             )
 
+                            logger.debug("cat is deleting dog contact")
                             cat.deleteDirectContact(dogId)
+                            logger.debug("cat is adding back dog provisional contact")
                             assertEquals(
                                 0,
                                 cat.addProvisionalContact(dogId).mostRecentHelloTsMillis
@@ -1873,7 +1878,7 @@ class MessagingTest : BaseMessagingTest() {
 internal suspend fun <T : Any> Messaging.waitFor(
     path: String,
     testCase: String,
-    duration: Duration = 10.seconds,
+    duration: Duration = 20.seconds,
     check: ((T) -> Boolean)? = null
 ): T {
     val maxWait = duration.toLongMilliseconds()

--- a/messaging/src/main/java/io/lantern/messaging/Messaging.kt
+++ b/messaging/src/main/java/io/lantern/messaging/Messaging.kt
@@ -42,6 +42,12 @@ class UnknownSenderException(internal val senderId: String) :
     Exception("Unknown sender")
 
 /**
+ * This exception indicates that a provisional message like a hello was received from an unknown
+ * sender (i.e. someone not in the list of provisional contacts)
+ */
+class UnknownProvisionalSenderException() : Exception("Unknown provisional sender")
+
+/**
  * This exception indicates that an attempt was made to upload an attachment larger than the
  * supported size.
  */


### PR DESCRIPTION
Prior to this change, we were processing Hello messages from unknown senders. This results in us recording session keys for those senders. To someone inspecting the data store, the presence of these session keys could be taken to imply that the user has been in communication with the person in question. It's better to just not have a record of these.

Also, prior to this change, in testing provisional contacts, I would sometimes encounter an "empty key" error when encrypting an outbound hello. This change resolves that. TBH I'm not 100% clear on why, but I'll take it.

- [x] Do the tests pass? Consistently?
- [x] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [x] Can it be QA’d in staging or something like staging?
- [x] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [x] Do we know how we’re going to deploy this?
- [x] Are we clear on what the support and maintenance impact is?
- [x] Did you create new documentation? Is it accessible and in the right place?
- [x] Has existing documentation been updated?
- [x] Have you logged tickets for related technical debt with the label “techdebt”?