### PR TITLE
Require displayName to be set prior to adding provisional contacts

### DIFF
--- a/messaging/src/androidTest/java/io/lantern/messaging/MessagingTest.kt
+++ b/messaging/src/androidTest/java/io/lantern/messaging/MessagingTest.kt
@@ -237,6 +237,14 @@ class MessagingTest : BaseMessagingTest() {
                             logger.debug("Cat is $catId")
                             logger.debug("Dog is $dogId")
 
+                            dog.unsafeSetMyDisplayName("")
+                            try {
+                                dog.addProvisionalContact(catId)
+                                fail("should not be allowed to add provisional contacts while our displayName is blank") // ktlint-disable max-line-length
+                            } catch (e: InvalidDisplayNameException) {
+                                // okay
+                            }
+
                             // We use unsafeSetMyDisplayName to keep the name from being sanitized
                             // here, which allows us to test that it gets sanitized when the
                             // provisional contact turns into a real contact.

--- a/messaging/src/androidTest/java/io/lantern/messaging/MessagingTest.kt
+++ b/messaging/src/androidTest/java/io/lantern/messaging/MessagingTest.kt
@@ -234,6 +234,9 @@ class MessagingTest : BaseMessagingTest() {
                             val dogId = dog.myId.id
                             val catId = cat.myId.id
 
+                            logger.debug("Cat is $catId")
+                            logger.debug("Dog is $dogId")
+
                             // We use unsafeSetMyDisplayName to keep the name from being sanitized
                             // here, which allows us to test that it gets sanitized when the
                             // provisional contact turns into a real contact.
@@ -309,7 +312,9 @@ class MessagingTest : BaseMessagingTest() {
                                 "no provisional contact should be stored for an existing contact"
                             )
 
+                            logger.debug("cat is deleting dog contact")
                             cat.deleteDirectContact(dogId)
+                            logger.debug("cat is adding back dog provisional contact")
                             assertEquals(
                                 0,
                                 cat.addProvisionalContact(dogId).mostRecentHelloTsMillis
@@ -1873,7 +1878,7 @@ class MessagingTest : BaseMessagingTest() {
 internal suspend fun <T : Any> Messaging.waitFor(
     path: String,
     testCase: String,
-    duration: Duration = 10.seconds,
+    duration: Duration = 20.seconds,
     check: ((T) -> Boolean)? = null
 ): T {
     val maxWait = duration.toLongMilliseconds()

--- a/messaging/src/main/java/io/lantern/messaging/CryptoWorker.kt
+++ b/messaging/src/main/java/io/lantern/messaging/CryptoWorker.kt
@@ -786,7 +786,8 @@ internal class CryptoWorker(
             when (transferMsg.contentCase) {
                 Model.TransferMessage.ContentCase.HELLO ->
                     if (!tx.contains(senderId.directContactPath) &&
-                        !tx.contains(senderId.provisionalContactPath)) {
+                        !tx.contains(senderId.provisionalContactPath)
+                    ) {
                         throw UnknownProvisionalSenderException()
                     }
                 else ->

--- a/messaging/src/main/java/io/lantern/messaging/Messaging.kt
+++ b/messaging/src/main/java/io/lantern/messaging/Messaging.kt
@@ -316,8 +316,14 @@ class Messaging(
     //
     // If they're already a contact, this simply sends them a hello but doesn't add a provisional
     // contact.
-    @Throws(InvalidKeyException::class)
+    @Throws(InvalidKeyException::class, InvalidDisplayNameException::class)
     fun addProvisionalContact(unsafeContactId: String): ProvisionalContactResult {
+        db.get<Model.Contact>(Schema.PATH_ME)?.let { me ->
+            if (me.displayName.isNullOrEmpty()) {
+                throw InvalidDisplayNameException()
+            }
+        }
+
         val contactId = unsafeContactId.sanitizedContactId
 
         val expiresAt = now + provisionalContactsExpireAfterSeconds.secondsToMillis

--- a/messaging/src/main/java/io/lantern/messaging/Messaging.kt
+++ b/messaging/src/main/java/io/lantern/messaging/Messaging.kt
@@ -42,6 +42,12 @@ class UnknownSenderException(internal val senderId: String) :
     Exception("Unknown sender")
 
 /**
+ * This exception indicates that a provisional message like a hello was received from an unknown
+ * sender (i.e. someone not in the list of provisional contacts)
+ */
+class UnknownProvisionalSenderException() : Exception("Unknown provisional sender")
+
+/**
  * This exception indicates that an attempt was made to upload an attachment larger than the
  * supported size.
  */


### PR DESCRIPTION
Closes getlantern/android-lantern#373.

- [x] Do the tests pass? Consistently?
- [x] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [x] Can it be QA’d in staging or something like staging?
- [x] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [x] Do we know how we’re going to deploy this?
- [x] Are we clear on what the support and maintenance impact is?
- [ ] Did you create new documentation? Is it accessible and in the right place?
- [ ] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?