### PR TITLE
Only mark hasReceivedMessage as true on inbound messages

### DIFF
--- a/messaging/src/androidTest/java/io/lantern/messaging/MessagingTest.kt
+++ b/messaging/src/androidTest/java/io/lantern/messaging/MessagingTest.kt
@@ -1516,8 +1516,22 @@ class MessagingTest : BaseMessagingTest() {
             dog.db.introductionMessage(ownerId, catId)?.value?.value?.introduction?.status
         )
 
+        // send a message to cat
+        dog.sendToDirectContact(catId, text = "Hi Cat")
+        val catContactAfterSend = dog.db.get<Model.Contact>(catId.directContactPath)
+        assertFalse(
+            catContactAfterSend?.hasReceivedMessage == true,
+            "Should not have received message from cat prior to cat accepting introduction"
+        )
+
         dog.acceptIntroduction(ownerId, fishId)
         cat.acceptIntroduction(ownerId, dogId.toUpperCase())
+        dog.waitFor<Model.Contact>(
+            catId.directContactPath,
+            "dog's cat contact should show that it received a message after cat accepted introduction" // ktlint-disable max-line-length
+        ) {
+            it.hasReceivedMessage
+        }
 
         // send a duplicate introduction for fish from dog to cat (but with a different displayName)
         dog.addOrUpdateDirectContact(fishId, "Dogfish")

--- a/messaging/src/main/java/io/lantern/messaging/Messaging.kt
+++ b/messaging/src/main/java/io/lantern/messaging/Messaging.kt
@@ -1006,7 +1006,9 @@ class Messaging(
             .setMostRecentMessageTs(msg.ts)
             .setMostRecentMessageDirection(msg.direction)
             .setMostRecentMessageText(msg.text)
-            .setHasReceivedMessage(true)
+        if (msg.direction == Model.MessageDirection.IN) {
+            updatedContactBuilder.hasReceivedMessage = true
+        }
         if (msg.attachmentsCount > 0) {
             updatedContactBuilder.mostRecentAttachmentMimeType =
                 msg.attachmentsMap.values.iterator().next().attachment.mimeType


### PR DESCRIPTION
Closes getlantern/android-lantern#382

- [x] Do the tests pass? Consistently?
- [x] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [x] Can it be QA’d in staging or something like staging?
- [x] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [x] Do we know how we’re going to deploy this?
- [x] Are we clear on what the support and maintenance impact is?
- [ ] Did you create new documentation? Is it accessible and in the right place?
- [ ] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?