### PR TITLE
Added support for contact verification

### DIFF
--- a/messaging/src/main/java/io/lantern/messaging/Migrations.kt
+++ b/messaging/src/main/java/io/lantern/messaging/Migrations.kt
@@ -1,0 +1,57 @@
+package io.lantern.messaging
+
+import io.lantern.db.Transaction
+import mu.KotlinLogging
+
+const val versionField = "_migrationsDbVersion"
+
+private val logger = KotlinLogging.logger {}
+
+private class Migration(val version: Int, val apply: () -> Unit) : Comparable<Migration> {
+    override fun compareTo(other: Migration): Int = this.version - other.version
+}
+
+/**
+ * Migrations applies database migrations to keep schema and data up-to-date.
+ */
+class Migrations(private val messaging: Messaging) {
+    fun apply() {
+        messaging.db.mutate { tx ->
+            val currentVersion = tx.get<Int>(versionField) ?: 0
+            logger.debug("current database version is $currentVersion")
+            migrations.forEach { (version, apply) ->
+                if (version > currentVersion) {
+                    logger.debug("applying migration to version $version")
+                    apply(tx)
+                }
+            }
+            val newVersion = migrations.lastKey()
+            tx.put(versionField, newVersion)
+            logger.debug("migrated database to version $newVersion")
+        }
+    }
+
+    // Define migrations here. Whenever you update the messaging-android library with changes that
+    // are incompatible with the prior version, add a new migration function in here with a new
+    // version number that's higher than the prior migration.
+    private val migrations = sortedMapOf<Int, (tx: Transaction) -> Unit> (
+        1 to { tx ->
+            // Prior to this, we did not allow messages from unrecognized contacts, nor did we allow
+            // explicit verification of contacts, so we mark all existing contacts UNVERIFIED.
+            tx.list<Model.Contact>(Schema.PATH_CONTACTS.path("%")).forEach { contact ->
+                tx.put(
+                    contact.path,
+                    contact.value.toBuilder()
+                        .setVerificationLevel(Model.VerificationLevel.UNVERIFIED).build()
+                )
+
+                // decrypt any "spam" we received from this Contact prior to adding them
+                tx.list<ByteArray>(contact.value.spamQuery)
+                    .forEach { (spamPath, unidentifiedSenderMessage) ->
+                        messaging.cryptoWorker.doDecryptAndStore(unidentifiedSenderMessage)
+                        tx.delete(spamPath)
+                    }
+            }
+        }
+    )
+}

--- a/messaging/src/main/java/io/lantern/messaging/Schema.kt
+++ b/messaging/src/main/java/io/lantern/messaging/Schema.kt
@@ -96,9 +96,6 @@ val Model.Contact.spamQuery: String get() = contactId.spamQuery
 
 val Model.ContactId.spamQuery: String get() = Schema.PATH_SPAM.path(id, "%")
 
-val String.randomSpamPath: String
-    get() = Schema.PATH_SPAM.path(this, now, randomMessageId.base32)
-
 val Model.StoredMessage.contactMessagePath: String
     get() =
         Schema.PATH_CONTACT_MESSAGES.path(

--- a/messaging/src/main/protos/Model.proto
+++ b/messaging/src/main/protos/Model.proto
@@ -28,6 +28,14 @@ enum ContactSource {
   APP3 = 4; // application-specific source 3
   APP4 = 5; // application-specific source 4
   APP5 = 6; // application-specific source 5
+  UNSOLICITED = 7; // contact was added upon receipt of unsolicited message
+}
+
+// How well do we know a contact.
+enum VerificationLevel {
+  UNACCEPTED = 0; // contact hasn't even been accepted into contact list yet
+  UNVERIFIED = 1; // we think we know who this is, but we haven't verified their key fingerprint
+  VERIFIED = 2; // we've verified their key fingerprint
 }
 
 // A contact in the address book
@@ -46,6 +54,8 @@ message Contact {
   int64 firstReceivedMessageTs = 10; // the timestamp of when the first message was received from this contact (excluding control messages)
   bool hasReceivedMessage = 11; // boolean indicating whether or not the contact has received any message (including control messages)
   int64 mostRecentHelloTs = 12; // the timestamp of the most recent hello received from this Contact (used for bidirectional contact adding)
+  VerificationLevel verificationLevel = 15; // how well do we know this contact
+  string numericFingerprint = 16; // a numeric fingerprint of this contact (depends on our own messenger ID)
 }
 
 // A provisional direct contact that is not yet in the address book. If we receive a Hello from that
@@ -56,6 +66,7 @@ message ProvisionalContact {
   string contactId = 1; // the ID of the contact (base32 encoded)
   int64 expiresAt = 2; // the unix timestamp in milliseconds of when this provisional contact expires
   ContactSource source = 3; // source from which the Contact was added
+  VerificationLevel verificationLevel = 4; // how well do we know this contact
 }
 
 // An attachment to a Message
@@ -95,9 +106,10 @@ message AttachmentWithThumbnail {
 message Introduction {
   bytes id = 1; // the id of the person to whom you're being introduced
   string displayName = 2; // the display name of person to whom you're being introduced
+  VerificationLevel verificationLevel = 3; // how well does the introducer know this contact
 }
 
-// Details of an Introduction (attached to both a StoredMessage as well as a StoredIntroduction
+// Details of an Introduction (attached to a StoredMessage)
 message IntroductionDetails {
   enum IntroductionStatus {
     PENDING = 0; // introduction has been made but has not yet been accepted/rejected
@@ -110,6 +122,7 @@ message IntroductionDetails {
   // someone else.
   string originalDisplayName = 3; // the original display name of the introduction, this will never change
   IntroductionStatus status = 4; // the status of the introduction
+  VerificationLevel verificationLevel = 5; // how well does the introducer know this contact
 }
 
 // A text message with attachments, the primary type of message exchanged by users.
@@ -168,7 +181,6 @@ message DisappearSettings {
 // A Hello from a Contact. If this Hello is not marked as final, we'll respond with a final Hello of
 // our own. Hellos are only processed in conjunction with ProvisionalContacts.
 message Hello {
-  string displayName = 1; // the display name that we should use for this Contact
   bool final = 2; // indicates whether this is a final hello
 }
 


### PR DESCRIPTION
This adds support for our new contact adding/verification flows by doing the following:

1. Track a verification status on each contact that can be set by the API consumer when creating contacts
2. Allow receipt of unsolicited messages from unknown contacts, which results in the addition of an `UNACCEPTED` contact. These contacts and their messages can/should be separated out from other contacts in the UI
3. Provides API for accepting unaccepted contacts
4. Provides API for marking contacts as verified
5. Allow setting a verification level on provisional contacts which will apply after those provisional contacts are added as real contacts (used when scanning contact QR codes)
6. On introductions, allow communicating the verification level of the introduced contact relative to the introducer. When the introduction is accepted, on the accepting end we use the lesser of the two verification levels
7. Include a fingerprint on each contact that can be used to perform visual contact verification (e.g. on a voice call)
8. Add a framework for performing database migrations and use this framework to mark all existing contacts as "VERIFIED" since currently the only way to add contacts is via QR code scanning, which effectively results in verified contacts
9. Don't send the display name in the provisional contact flow, people will need to set it themselves
10. Remove ability to set your own display name since that's not needed anymore

- [x] Do the tests pass? Consistently?
- [x] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [x] Can it be QA’d in staging or something like staging?
- [x] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [x] Do we know how we’re going to deploy this?
- [x] Are we clear on what the support and maintenance impact is?
- [ ] Did you create new documentation? Is it accessible and in the right place?
- [ ] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?