### PR TITLE
Added support for ChatNumber

### DIFF
--- a/messaging/build.gradle
+++ b/messaging/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     implementation 'com.android.support:exifinterface:28.0.0'
     implementation 'com.j256.simplemagic:simplemagic:1.16'
 
-    api 'com.github.getlantern:db-android:5c6beff7c9'
+    api 'com.github.getlantern:db-android:0eed7e8d75'
     implementation 'com.github.getlantern:libsignal-protocol-java:47e9418c74'
     implementation 'com.github.getlantern:libsignal-metadata-java:f0f1a0ea15'
 

--- a/messaging/src/androidTest/java/io/lantern/messaging/ChatNumberEncodingTest.kt
+++ b/messaging/src/androidTest/java/io/lantern/messaging/ChatNumberEncodingTest.kt
@@ -26,7 +26,9 @@ class ChatNumberEncodingTest {
             val expected = ChatNumberEncoding.encodeToString(b, 82)
             val actual = ChatNumberEncoding.encodeToString(
                 ChatNumberEncoding.decodeFromString(
-                    expected!!, 32
+                    // insert spurious 5's to make sure they're ignored
+                    "55${expected!!.substring(0, 12)}55${expected!!.substring(12)}",
+                    32
                 ),
                 82
             )

--- a/messaging/src/androidTest/java/io/lantern/messaging/ChatNumberEncodingTest.kt
+++ b/messaging/src/androidTest/java/io/lantern/messaging/ChatNumberEncodingTest.kt
@@ -1,0 +1,36 @@
+package io.lantern.messaging
+
+import java.util.Random
+import kotlin.test.assertEquals
+import org.junit.Test
+import org.whispersystems.libsignal.util.Base32
+
+class ChatNumberEncodingTest {
+    @Test
+    open fun testEncodeToString() {
+        val b = Base32.humanFriendly.decodeFromString(
+            "rfu2495fqazzpq1e3xkj1skmr9785hwbxggpr17ut1htj4h9nhyy"
+        )
+        assertEquals(
+            "2277029271600308397119018701998194490680040839333862997699030902896411310611021743",
+            ChatNumberEncoding.encodeToString(b, 82)
+        )
+    }
+
+    @Test
+    fun testRoundTrip() {
+        val random = Random()
+        for (i in 0..9999) {
+            val b = ByteArray(32)
+            random.nextBytes(b)
+            val expected = ChatNumberEncoding.encodeToString(b, 82)
+            val actual = ChatNumberEncoding.encodeToString(
+                ChatNumberEncoding.decodeFromString(
+                    expected!!, 32
+                ),
+                82
+            )
+            assertEquals(expected, actual)
+        }
+    }
+}

--- a/messaging/src/androidTest/java/io/lantern/messaging/MessagingTest.kt
+++ b/messaging/src/androidTest/java/io/lantern/messaging/MessagingTest.kt
@@ -282,7 +282,7 @@ class MessagingTest : BaseMessagingTest() {
                             }
 
                             sendAndVerify(
-                                "cat sends a message to dog after having been removed and re-added",
+                                "cat sends a message to dog after having been removed and re-added", // ktlint-disable max-line-length
                                 cat,
                                 dog,
                                 "hello again dog"
@@ -292,6 +292,63 @@ class MessagingTest : BaseMessagingTest() {
                                 2,
                                 dog.db.listPaths(Schema.PATH_CONTACT_MESSAGES.path("%")).count(),
                                 "dog should have 2 messages from cat, the message sent while cat was not a contact should have been included" // ktlint-disable max-line-length
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testChatNumber() {
+        testInCoroutine {
+            newDB.use { dogDB ->
+                newDB.use { catDB ->
+                    newMessaging(dogDB, "dog").with { dog ->
+                        newMessaging(catDB, "cat").with { cat ->
+                            val catShortNumber = cat.waitFor<Model.Contact>(
+                                Schema.PATH_ME,
+                                "cat gets own ChatNumber)"
+                            ) {
+                                it.hasChatNumber()
+                            }.chatNumber.shortNumber
+
+                            val nonExistentNumber = CompletableFuture<Model.ChatNumber>()
+                            dog.findChatNumberByShortNumber("asd") { number, err ->
+                                if (err != null) {
+                                    nonExistentNumber.completeExceptionally(err)
+                                } else {
+                                    nonExistentNumber.complete(number)
+                                }
+                            }
+                            try {
+                                nonExistentNumber.get()
+                                fail("finding number using non-existent short number should fail")
+                            } catch (t: Throwable) {
+                                // okay
+                            }
+
+                            val catNumber = CompletableFuture<Model.ChatNumber>()
+                            dog.findChatNumberByShortNumber(catShortNumber) { number, err ->
+                                if (err != null) {
+                                    catNumber.completeExceptionally(err)
+                                } else {
+                                    catNumber.complete(number)
+                                }
+                            }
+                            assertEquals(catShortNumber, catNumber.get().shortNumber)
+
+                            dog.addOrUpdateDirectContact(
+                                chatNumber = catNumber.get(),
+                                displayName = "Cat",
+                                minimumVerificationLevel = Model.VerificationLevel.UNVERIFIED
+                            )
+                            sendAndVerify(
+                                "dog sends a message to cat",
+                                dog,
+                                cat,
+                                "hi cat"
                             )
                         }
                     }

--- a/messaging/src/androidTest/java/io/lantern/messaging/MessagingTest.kt
+++ b/messaging/src/androidTest/java/io/lantern/messaging/MessagingTest.kt
@@ -1074,6 +1074,9 @@ class MessagingTest : BaseMessagingTest() {
                 newMessaging(dogDB, "dog").with { dog ->
                     val msgs = sendAndVerify("dog sends note to dog", dog, dog, "hi myself")
                     assertNotNull(msgs.received)
+                    val me = dog.db.get<Model.Contact>(Schema.PATH_ME)!!
+                    assertEquals(true, me.isMe)
+                    assertEquals(true, dog.db.get<Model.Contact>(me.dbPath)?.isMe)
                 }
             }
         }

--- a/messaging/src/main/java/io/lantern/messaging/AuthenticatedClientWorker.kt
+++ b/messaging/src/main/java/io/lantern/messaging/AuthenticatedClientWorker.kt
@@ -49,4 +49,19 @@ internal class AuthenticatedClientWorker(
     override fun onConfigUpdate(cfg: Messages.Configuration) {
         messaging.updateConfig(cfg)
     }
+
+    override fun onConnected(client: AuthenticatedClient, number: Messages.ChatNumber) {
+        super.onConnected(client)
+        messaging.db.mutate { tx ->
+            tx.get<Model.Contact>(Schema.PATH_ME)?.let { me ->
+                // only set number once
+                if (!me.hasChatNumber()) {
+                    tx.put(
+                        Schema.PATH_ME,
+                        me.toBuilder().setChatNumber(number.pbuf).build()
+                    )
+                }
+            }
+        }
+    }
 }

--- a/messaging/src/main/java/io/lantern/messaging/ChatNumberEncoding.kt
+++ b/messaging/src/main/java/io/lantern/messaging/ChatNumberEncoding.kt
@@ -1,0 +1,128 @@
+package io.lantern.messaging
+
+import java.math.BigInteger
+import java.nio.ByteBuffer
+import java.util.HashMap
+import org.whispersystems.libsignal.ecc.ECPublicKey
+
+/**
+ * Provides a human-friendly encoding that looks like a phone number but isn't usually a dialable
+ * phone number, because it doesn't start with 0 or 1 (as is required in most countries). This
+ * encoding treats a byte array as a big-endian number. The first (most significant) 2 bits of data
+ * are encoded using a modified base4 encoding (digits 2, 3, 4, 6 instead of the standard 0-4) and the
+ * remaining data is encoded in base9 (omitting digit 5) and left-padded with '0's to meet the desired length.
+ *
+ * This encoding permits the inclusion of arbitrary '5's anywhere in the encoded string, which it simply ignores. This
+ * can be used to visually differentiate the beginning of two otherwise very similar numbers, for example, given:
+ *
+ * 2222222222222222222222222222222222222222222222222222222222222222222222222222222
+ * 2222222222222222222222222222222222222222222222222222222222222222222222222222223
+ *
+ * We can change the 2nd number to the following equivalent value
+ *
+ * 522222222222252222222222222222222222222222222222222222222222222222222222222222223
+ */
+object ChatNumberEncoding {
+    private val base4Table: MutableMap<Byte, Char> = HashMap()
+    private val base4TableReverse: MutableMap<Char, Int> = HashMap()
+
+    init {
+        addBase4Mapping(0, '2')
+        addBase4Mapping(1, '3')
+        addBase4Mapping(2, '4')
+        addBase4Mapping(3, '6')
+    }
+
+    private fun addBase4Mapping(b: Byte, c: Char) {
+        base4Table[b] = c
+        base4TableReverse[c] = byteToUnsigned(b)
+    }
+
+    /**
+     * Encodes the given bytes using ChatNumber encoding. The resulting string will be of target
+     * length using '0's after the first digit in order to pad up to the targetLength.
+     *
+     * @param b
+     * @param targetLength
+     * @return
+     */
+    fun encodeToString(b: ByteArray, targetLength: Int): String {
+        val _b = b.copyOf()
+        val head = (byteToUnsigned(_b[0]) ushr 6).toByte()
+        _b[0] = (byteToUnsigned(_b[0]) shl 2).toByte()
+        val tail = shiftBase9(BigInteger(1, _b).toString(9))
+        val result = StringBuilder(targetLength)
+        result.append(base4Table[head])
+        var padding = targetLength - 1 - tail.length
+        if (padding < 0) {
+            padding = 0
+        }
+        for (i in 0 until padding) {
+            result.append('0')
+        }
+        result.append(tail)
+        return result.toString()
+    }
+
+    /**
+     * Decodes the given ChatNumber string into a byte[] of targetSize. If the string doesn't
+     * contain enough data to fill targetSize, the byte[] will contain leading zeros.
+     *
+     * This function ignores any leading characters other than 2, 3, 4 or 6, and any subsequent 5s.
+     *
+     * @param s
+     * @param targetSize
+     * @return
+     */
+    fun decodeFromString(string: String, targetSize: Int): ByteArray {
+        val s = string.replace("^[015789]+".toRegex(), "")
+        val head = base4TableReverse[s[0]]!!
+        var _tail = BigInteger(unshiftBase9(s.substring(1)), 9)
+        val buf = ByteBuffer.allocate(targetSize)
+        for (i in targetSize / 4 - 1 downTo 0) {
+            buf.putInt(i * 4, _tail.toInt())
+            _tail = _tail.shiftRight(32)
+        }
+        val tail = buf.array()
+        tail[0] = (head shl 6 or (byteToUnsigned(tail[0]) ushr 2)).toByte()
+        return tail
+    }
+
+    /**
+     * Builds an ECPublicKey from the given chatNumber.
+     */
+    fun identityKey(chatNumber: String): ECPublicKey =
+        ECPublicKey(decodeFromString(chatNumber, 32))
+
+    private fun shiftBase9(s: String): String {
+        val result = StringBuilder(s.length)
+        for (element in s) {
+            val c = element
+            if (c < '5') {
+                result.append(c)
+            } else {
+                result.append((c.toInt() + 1).toChar())
+            }
+        }
+        return result.toString()
+    }
+
+    private fun unshiftBase9(s: String): String {
+        val result = StringBuilder(s.length)
+        for (element in s) {
+            val c = element
+            if (c < '5') {
+                result.append(c)
+            } else if (c == '5') {
+                // ignore 5s
+            } else {
+                result.append((c.toInt() - 1).toChar())
+            }
+        }
+        return result.toString()
+    }
+
+    private fun byteToUnsigned(b: Byte): Int {
+        return b.toInt() and 0xFF
+    }
+}

--- a/messaging/src/main/java/io/lantern/messaging/Messaging.kt
+++ b/messaging/src/main/java/io/lantern/messaging/Messaging.kt
@@ -242,9 +242,11 @@ class Messaging(
     }
 
     /**
-     * Adds or updates the given direct contact.
+     * Adds or updates the given direct contact. The contact is identified by either unsafeId or
+     * chatNumber.
      *
      * @param unsafeId the base32 encoded public identity key of the contact
+     *                 (if unspecified, chatNumber is used instead)
      * @param displayName optional human-friendly display name for this contact
      *                    (if unspecified, existing displayName is left alone)
      * @param source optional identifier of the source of this contact
@@ -254,6 +256,8 @@ class Messaging(
      *                       (application IDs are added to existing set)
      * @param minimumVerificationLevel the contact's verification will be set to the greater of this
      *                                 or the current verificationLevel (defaults to UNVERIFIED)
+     * @param chatNumber the ChatNumber to associate with this contact
+     *                   (if unspecified, the existing ChatNumber is left alone)
      * @param updateApplicationData optional function to manipulate application specific data on the
      *                              contact
      * @return the created or updated Contact
@@ -463,6 +467,12 @@ class Messaging(
         return result
     }
 
+    /**
+     * Looks up a ChatNumber from the short version of the number.
+     *
+     * @param shortNumber the short number by which to search
+     * @param cb callback that gets called with result (or exception if something went wrong)
+     */
     fun findChatNumberByShortNumber(
         shortNumber: String,
         cb: (Model.ChatNumber?, Throwable?) -> Unit

--- a/messaging/src/main/java/io/lantern/messaging/Messaging.kt
+++ b/messaging/src/main/java/io/lantern/messaging/Messaging.kt
@@ -311,7 +311,13 @@ class Messaging(
         updateApplicationData: ((MutableMap<String, Any>) -> Unit)? = null
     ): Model.Contact =
         doAddOrUpdateContact(unsafeContactId) { contact, _ ->
-            chatNumber?.let { contact.chatNumber = chatNumber }
+            chatNumber?.let {
+                if (chatNumber.isComplete) {
+                    // only record complete ChatNumbers
+                    // if we don't have a complete ChatNumber, we'll later get it from the server
+                    contact.chatNumber = chatNumber
+                }
+            }
             displayName?.let { contact.displayName = it }
             source?.let { it -> contact.source = it }
             applicationIds?.let { it ->

--- a/messaging/src/main/java/io/lantern/messaging/Messaging.kt
+++ b/messaging/src/main/java/io/lantern/messaging/Messaging.kt
@@ -191,16 +191,16 @@ class Messaging(
             tx.get(Schema.PATH_ME) ?: tx.put(
                 Schema.PATH_ME,
                 Model.Contact.newBuilder()
-                    .setContactId(identityKeyPair.publicKey.toString().directContactId).build()
+                    .setContactId(identityKeyPair.publicKey.toString().directContactId)
+                    .setIsMe(true)
+                    .build()
             )
         }
         myId = me.contactId
 
         // add myself as a contact to record notes to myself
         doAddOrUpdateContact(myId) { contact, isNew ->
-            if (isNew) {
-                contact.displayName = "Note to self"
-            }
+            contact.isMe = true
         }
 
         // immediately request some upload authorizations so that we're ready to upload attachments

--- a/messaging/src/main/java/io/lantern/messaging/Migrations.kt
+++ b/messaging/src/main/java/io/lantern/messaging/Migrations.kt
@@ -80,6 +80,12 @@ class Migrations(private val messaging: Messaging) {
             ).groupBy { it.value.introduction.to }.keys.forEach {
                 messaging.updateBestIntroduction(tx, it)
             }
+        },
+
+        3 to { tx, _ ->
+            tx.get<Model.Contact>(Schema.PATH_ME)?.let { me ->
+                tx.put(Schema.PATH_ME, me.toBuilder().setIsMe(true).build())
+            }
         }
     )
 }

--- a/messaging/src/main/java/io/lantern/messaging/Schema.kt
+++ b/messaging/src/main/java/io/lantern/messaging/Schema.kt
@@ -4,6 +4,7 @@ import com.google.protobuf.ByteString
 import io.lantern.db.Detail
 import io.lantern.db.Queryable
 import io.lantern.db.Raw
+import io.lantern.messaging.tassis.Messages
 import org.whispersystems.libsignal.DeviceId
 import org.whispersystems.libsignal.ecc.ECPublicKey
 import org.whispersystems.libsignal.util.Base32
@@ -169,3 +170,14 @@ val Model.Contact.fullText: String
 
 val Model.StoredMessage.fullText: String?
     get() = text
+
+val Messages.ChatNumber.pbuf: Model.ChatNumber
+    get() = Model.ChatNumber.newBuilder()
+        .setNumber(number)
+        .setShortNumber(shortNumber)
+        .setDomain(domain).build()
+
+val Model.ChatNumber.directContactId: Model.ContactId
+    get() = ECPublicKey(
+        ChatNumberEncoding.decodeFromString(number, 32)
+    ).toString().directContactId

--- a/messaging/src/main/java/io/lantern/messaging/Schema.kt
+++ b/messaging/src/main/java/io/lantern/messaging/Schema.kt
@@ -181,3 +181,6 @@ val Model.ChatNumber.directContactId: Model.ContactId
     get() = ECPublicKey(
         ChatNumberEncoding.decodeFromString(number, 32)
     ).toString().directContactId
+
+val Model.ChatNumber.isComplete: Boolean
+    get() = number.isNotEmpty() && shortNumber.isNotEmpty() && domain.isNotEmpty()

--- a/messaging/src/main/java/io/lantern/messaging/Worker.kt
+++ b/messaging/src/main/java/io/lantern/messaging/Worker.kt
@@ -61,7 +61,7 @@ internal abstract class Worker(
         }
     }
 
-    protected fun retryFailed(cmd: () -> Unit) {
+    internal fun retryFailed(cmd: () -> Unit) {
         if (retryDelayMillis == null) {
             throw Exception("Attempted to retry but retries are disabled")
         }

--- a/messaging/src/main/protos/Messages.proto
+++ b/messaging/src/main/protos/Messages.proto
@@ -15,7 +15,9 @@
  * Authentication is performed using a challenge-response pattern in which the server sends
  * an authentication challenge to the client and the client responds with a signed authentication
  * response identifying its identityKey and deviceId. On anonymous connections, clients simply ignore the
- * authentication challenge.
+ * authentication challenge. Successful authentications are acknowledged with a Number that gives information
+ * about the IdentityKey number under which the authenticated user is registered. This number is constant over
+ * time.
  *
  * Messages sent from clients to servers follow a request/response pattern. The server will always
  * respond to these with either an Ack or a typed response. In the event of an error, it will respond
@@ -160,6 +162,27 @@ message UploadAuthorizations {
   repeated UploadAuthorization authorizations = 1;
 }
 
+// Requires anonymous connection
+//
+// A request to look up a ChatNumber corresponding to a short number.
+message FindChatNumberByShortNumber {
+  string shortNumber = 1; // the short number for which to look up the ChatNumber
+}
+
+// Requires anonymous connection
+//
+// A request to look up a ChatNumber corresponding to an IdentityKey.
+message FindChatNumberByIdentityKey {
+  bytes identityKey = 1; // the identity key for which to look up the ChatNumber
+}
+
+// A number representing the IdentityKey in this system.
+message ChatNumber {
+  string number = 1; // a form of IdentityKey that looks like a phone number
+  string shortNumber = 2; // short version of the number
+  string domain = 3; // the domain within which the short number is registered
+}
+
 // The envelope for all messages sent to/from clients.
 message Message {
   uint32 sequence = 1; // the message sequence, either a unique number for request messages or the number of the request message to which a response message corresponds
@@ -179,6 +202,9 @@ message Message {
     UploadAuthorizations        uploadAuthorizations        = 14;
     OutboundMessage             outboundMessage             = 15;
     InboundMessage              inboundMessage              = 16;
+    FindChatNumberByShortNumber findChatNumberByShortNumber = 17;
+    FindChatNumberByIdentityKey findChatNumberByIdentityKey = 18;
+    ChatNumber                  chatNumber                  = 19;
   }
 }
 

--- a/messaging/src/main/protos/Model.proto
+++ b/messaging/src/main/protos/Model.proto
@@ -77,6 +77,7 @@ message Contact {
   bool blocked = 17; // flag indicating of the contact is blocked
   map<string, Datum> applicationData = 18; // place for applications to store app-specific data associated with the Contact
   ChatNumber chatNumber = 19; // for direct contacts, this is their chat number (looks like a phone number)
+  bool isMe = 20; // if true, this contact is the "me" contact (i.e. the contact representing the current user)
 }
 
 // A provisional direct contact that is not yet in the address book. If we receive a Hello from that

--- a/messaging/src/main/protos/Model.proto
+++ b/messaging/src/main/protos/Model.proto
@@ -20,6 +20,13 @@ message ContactId {
   string id = 2; // the public IdentityKey for direct contacts, the globally unique group id (type 4 UUID) for groups, both base32 encoded
 }
 
+// A numeric version of the IdentityKey encoded in a phone-number like encoding
+message ChatNumber {
+  string number = 1; // the full contact number (82 or more digits)
+  string shortNumber = 2; // the short version of the number by which the contact is registered with tassis
+  string domain = 3; // the domain on which the short number is registered (e.g. lantern.io)
+}
+
 enum ContactSource {
   UNKNOWN = 0; // source of contact is unknown
   INTRODUCTION = 1; // contact was added through introduction
@@ -69,6 +76,7 @@ message Contact {
   string numericFingerprint = 16; // a numeric fingerprint of this contact (depends on our own messenger ID)
   bool blocked = 17; // flag indicating of the contact is blocked
   map<string, Datum> applicationData = 18; // place for applications to store app-specific data associated with the Contact
+  ChatNumber chatNumber = 19; // for direct contacts, this is their chat number (looks like a phone number)
 }
 
 // A provisional direct contact that is not yet in the address book. If we receive a Hello from that


### PR DESCRIPTION
This does several things:

- Updates the model to track a ChatNumber on each Contact
- Keeps track of your own ChatNumber at `/me`
- Looks up ChatNumber information for new and existing contacts as necessary
- Adds an API to look up ChatNumber using the short chat number
- Allows using ChatNumber instead of ContactId when adding or updating contacts

Unrelated to ChatNumber, this also pulls in a fix for full text indexing from https://github.com/getlantern/db-android/pull/11

NOTE - This depends on a non-backwards-compatible change in https://github.com/getlantern/tassis/pull/13. **This change has been deployed to tassis, breaking old clients that we've built for testing**

- [x] Do the tests pass? Consistently?
- [x] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [x] Can it be QA’d in staging or something like staging?
- [x] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [x] Do we know how we’re going to deploy this?
- [x] Are we clear on what the support and maintenance impact is?
- [x] Did you create new documentation? Is it accessible and in the right place?
- [x] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?